### PR TITLE
Fix/service setup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,11 @@ vsts_workfolder: "/home/{{ vsts_agent_user }}/work/"
 
 vsts_remove: false
 vsts_reinstall: false
+
+vsts_sudo_permissions:
+  - /bin/systemctl reload vsts-agent
+  - /bin/systemctl status vsts-agent
+  - /bin/systemctl start vsts-agent
+  - /bin/systemctl restart vsts-agent
+  - /bin/systemctl stop vsts-agent
+  - /bin/systemctl daemon-reload

--- a/tasks/rhel/configure_vsts_agent.yml
+++ b/tasks/rhel/configure_vsts_agent.yml
@@ -33,6 +33,12 @@
     - vsts_poolname|default("") == ""
     - vsts_deploymentgroupname|default("") == ""
 
+- name: Set sudo permissions
+  template:
+    src: sudo_permissions.j2
+    dest: /etc/sudoers.d/{{vsts_agent_user}}
+  when: vsts_sudo_permissions|default("") != ""
+
 - name: Configure vsts-agent
   command: "{{ install_command }}"
   args:

--- a/tasks/rhel/configure_vsts_agent.yml
+++ b/tasks/rhel/configure_vsts_agent.yml
@@ -1,6 +1,6 @@
 - name: Register base install command as fact in variable install_command
   set_fact:
-    install_command: "./config.sh --unattended --acceptteeeula --url {{vsts_server_url}} --auth PAT --token {{vsts_accesstoken}} --agent {{vsts_agent_name}} --work {{vsts_workfolder}} --replace"
+    install_command: "./config.sh --acceptteeeula --url {{vsts_server_url}} --auth PAT --token {{vsts_accesstoken}} --agent {{vsts_agent_name}} --work {{vsts_workfolder}} --runasservice"
 
 - name: Add agent pool to install command (default queue-agent)
   set_fact:

--- a/tasks/rhel/install_vsts_agent.yml
+++ b/tasks/rhel/install_vsts_agent.yml
@@ -13,23 +13,20 @@
 
 - name: Install required software for vsts-agent
   yum:
-    name: "{{item}}"
+    name:
+      - icu
+      - libunwind
+      - git
+      - python-pip
     state: installed
-  with_items:
-    - icu
-    - libunwind
-    - rh-git29
-    - python-pip
   become: true
   tags:
     - pkg
 
 - name: Pip install pexpect (we need a new-enough version that isn't packaged in redhat 7.x
   pip:
-    name: "{{item}}"
+    name: pexpect
     state: present
-  with_items:
-    - pexpect
   tags:
     - pkg
     - pexpect
@@ -40,22 +37,19 @@
   tags:
     - config
 
-- name: Initial installation of systemd service files and generation of runsvc.sh
-  command: "./svc.sh install {{vsts_agent_user}}"
-  args:
-    chdir: "{{vsts_agentfolder}}"
-    creates: "/etc/systemd/system/vsts.agent.{{ vsts_accountname }}.{{ vsts_agent_name }}.service"
+- name: Install systemd service file
+  template:
+    src: vsts-agent.service.j2
+    dest: /etc/systemd/system/vsts-agent.service
+    mode: "0755"
   become: true
-  when: dryrun is not defined
-  tags:
-    - config
-    - service
 
 - name: Enable and start vsts-agent service
-  service:
-    name: "vsts.agent.{{ vsts_accountname }}.{{ vsts_agent_name }}"
+  systemd:
+    name: vsts-agent
     enabled: yes
     state: started
+    daemon_reload: yes
   become: true
   when: dryrun is not defined
   tags:

--- a/tasks/rhel/main.yml
+++ b/tasks/rhel/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check if vsts agent service already installed
-  stat: path="/etc/systemd/system/vsts.agent.{{ vsts_accountname }}.{{ vsts_agent_name }}.service" 
+  stat: path="/etc/systemd/system/vsts-agent.service" 
   register: vsts_service_result
   failed_when: vsts_service_result is not defined
   ignore_errors: yes

--- a/tasks/rhel/uninstall_vsts_agent.yml
+++ b/tasks/rhel/uninstall_vsts_agent.yml
@@ -1,20 +1,38 @@
 ---
-  - name: Unconfigure vsts-agent - remove service
-    command: "./svc.sh uninstall"
-    args:
-      chdir: "{{vsts_agentfolder}}"
-      removes: "/etc/systemd/system/vsts.agent.{{ vsts_accountname }}.{{ vsts_agent_name }}.service"
-    when: vsts_remove|bool
+  - name: Disable vsts-agent systemd service
+    service:
+      name: vsts-agent
+      enabled: no
+      state: stopped
     become: true
+    when: vsts_remove|bool
     tags:
       - service
       - unconfig
 
+  - name: Remove vsts-agent systemd service file
+    file:
+      path: /etc/systemd/system/vsts-agent.service
+      state: absent
+    become: true
+
   - name: Unconfigure vsts-agent
-    command: "./config.sh remove --unattended --auth PAT --token {{vsts_accesstoken}}"
+    command: "./config.sh remove --unattended --auth PAT --token $VSTS_ACCESSTOKEN"
     args:
       chdir: "{{vsts_agentfolder}}"
+    environment:
+      VSTS_ACCESSTOKEN: "{{ vsts_accesstoken }}"
     become_user: "{{vsts_agent_user}}"
+    no_log: true
     when: vsts_remove|bool
     tags:
-      - unconfig    
+      - unconfig
+  
+  - name: Remove vsts-agent folders
+    file:
+      path: "{{ item }}"
+      state: absent
+    loop:
+      - "{{ vsts_agentfolder }}"
+      - "{{ vsts_workfolder }}"
+    become: true

--- a/templates/sudo_permissions.j2
+++ b/templates/sudo_permissions.j2
@@ -1,0 +1,6 @@
+Defaults:{{ vsts_agent_user }} !requiretty
+Defaults:{{ vsts_agent_user }} visiblepw
+
+{% for command in vsts_sudo_permissions -%}
+  {{ vsts_agent_user + ' ALL=(ALL) NOPASSWD: ' + command }}
+{% endfor %}

--- a/templates/vsts-agent.service.j2
+++ b/templates/vsts-agent.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Azure Pipelines Agent
+After=network.target
+
+[Service]
+ExecStart={{vsts_agentfolder}}bin/runsvc.sh
+User={{vsts_agent_user}}
+WorkingDirectory={{vsts_agentfolder}}
+KillMode=process
+KillSignal=SIGTERM
+TimeoutStopSec=5min
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR: 
- ignores the example svc.sh file created from the vsts config.sh and make an clean systemd service install.
- allow custom sudo permissions to vsts user, reducing attack exposure
 
**The problem:**
The default service name generated by config.sh contains deploymentpool that usually has "-" in it.
The svc.sh set service name with `systemd-escape --path`, witch finally creates .service files with weird names that this role does not expect.


**Breaking change:**
service name was changed to `vsts-agent`
managing the service:
`systemctl start|stop|restart|status vsts-agent`