### PR TITLE
feat/virtualmachineresourcetags

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,8 @@ vsts_poolname: ""
 vsts_deploymentgroupname: ""
 vsts_proxyurl: ""
 
+vsts_virtualmachineresourcetags: ""
+
 vsts_server_url: "https://dev.azure.com/{{ vsts_accountname }}"
 vsts_agent_name: "{{ ansible_hostname }}"
 vsts_agentfolder: "/opt/vsts-agent"

--- a/tasks/debian/configure_vsts_agent.yml
+++ b/tasks/debian/configure_vsts_agent.yml
@@ -19,6 +19,13 @@
     - vsts_deploymentgroupname|default("") != ""
     - vsts_projectname|default("") != ""
 
+- name: Add virtual machine resource tags to install command
+  set_fact:
+    install_command: "{{ install_command }} --addvirtualmachineresourcetags --virtualmachineresourcetags {{ vsts_virtualmachineresourcetags|quote }} "
+  when:
+    - environment_set is succeeded
+    - vsts_virtualmachineresourcetags | string
+
 - name: Fail for conflicting options for default agent x deployment agent
   fail:
     msg: "The vsts_poolname({{ vsts_poolname }}) and vsts_deploymentgroupname({{ vsts_deploymentgroupname }}) vars are present at same time, choose one of them to install the default queue/build agent or the deployment group agent."

--- a/tasks/rhel/configure.yml
+++ b/tasks/rhel/configure.yml
@@ -40,7 +40,7 @@
     install_command: "{{ install_command }} --addvirtualmachineresourcetags --virtualmachineresourcetags {{ vsts_virtualmachineresourcetags|quote }} "
   when:
     - environment_set is succeeded
-    - vsts_virtualmachineresourcetags|default("") != ""
+    - vsts_virtualmachineresourcetags | string
 
 - name: Fail for conflicting options for default agent x deployment agent x environment resource
   fail:

--- a/tasks/rhel/configure.yml
+++ b/tasks/rhel/configure.yml
@@ -35,6 +35,13 @@
     - vsts_environmentname|default("") != ""
     - vsts_projectname|default("") != ""
 
+- name: Add virtual machine resource tags to install command
+  set_fact:
+    install_command: "{{ install_command }} --addvirtualmachineresourcetags --virtualmachineresourcetags {{ vsts_virtualmachineresourcetags|quote }} "
+  when:
+    - environment_set is succeeded
+    - vsts_virtualmachineresourcetags|default("") != ""
+
 - name: Fail for conflicting options for default agent x deployment agent x environment resource
   fail:
     msg: "More than one agent type was found. Choose one of them to install. Options: vsts_poolname({{ vsts_poolname }}), vsts_deploymentgroupname({{ vsts_deploymentgroupname }}), vsts_environmentname({{ vsts_environmentname }})"


### PR DESCRIPTION
## Description

This PR enables "virtualmachinesresourcetags" usage during vsts agent installation.

## Motivation and Context

We can use a single environment for different deployments stages using virtual machine resource tags.

## How Has This Been Tested?

We tested this new feature in one of our deploys.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)