### PR TITLE
- Updating vsts agent to the version 2.200.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ vsts_github_api: "https://api.github.com/repos/Microsoft/vsts-agent/releases/lat
 
 # If vsts_agent_fullurl is set this specific version will be downloaded instead of latest
 # https://vstsagentpackage.azureedge.net/agent/2.129.0/vsts-agent-linux-x64-2.129.0.tar.gz
-vsts_agent_version: "2.189.0"
+vsts_agent_version: "2.200.2"
 vsts_agent_baseurl: "https://vstsagentpackage.azureedge.net/agent"
 vsts_agent_file: "vsts-agent-linux-x64-{{ vsts_agent_version }}.tar.gz"
 vsts_agent_fullurl: "{{ vsts_agent_baseurl }}/{{ vsts_agent_version }}/{{ vsts_agent_file }}"


### PR DESCRIPTION
Updating vsts agent version to remove dependency with log4j 1.2.x.