### PR TITLE
Fix: Add proxy environment variables to vsts-agent .env file

### DIFF
--- a/tasks/common/configure.yml
+++ b/tasks/common/configure.yml
@@ -24,6 +24,45 @@
     - vsts_proxy_username | length > 0
     - vsts_proxy_password | length > 0
 
+- name: Configure proxy environment variables
+  block:
+  - name: Add proxy-url to environment variables
+    set_fact: 
+      vsts_environment_variables: "{{ vsts_environment_variables + [{'name': item, 'value': vsts_proxyurl}] }}"
+    when: 
+      - vsts_proxy_username | length == 0
+      - vsts_proxy_password | length == 0
+    with_items:
+      - http_proxy
+      - https_proxy
+      - HTTP_PROXY
+      - HTTPS_PROXY
+
+  - name: Add proxy credentials to environment variables 
+    set_fact: 
+      vsts_environment_variables: "{{ vsts_environment_variables + [{'name': item, 'value': proxy_auth_url }] }}"
+    when: 
+      - vsts_proxy_username | length > 0
+      - vsts_proxy_password | length > 0
+    with_items:
+      - http_proxy
+      - https_proxy
+      - HTTP_PROXY
+      - HTTPS_PROXY
+    vars: 
+      proxy_schema: "{{ (vsts_proxyurl | split('//'))[0] }}"
+      proxy_url: "{{ (vsts_proxyurl | split('//'))[1] }}"
+      proxy_auth_url: "{{ proxy_schema + '//' + vsts_proxy_username + ':' + vsts_proxy_password + '@' + proxy_url }}"
+  
+  - name: Define bypass proxy urls to environment variables
+    set_fact:
+      vsts_environment_variables: "{{ vsts_environment_variables + [{'name': item, 'value': vsts_proxy_bypass }] }}"
+    when: vsts_proxy_bypass | length > 0
+    with_items:
+      - NO_PROXY
+      - no_proxy
+  when: vsts_proxyurl | length > 0
+
 - name: Add deployment group info to install command (deployment group agent)
   set_fact:
     vsts_install_command: "{{ vsts_install_command }} --projectname \"{{ vsts_projectname }}\" --deploymentgroup --deploymentgroupname {{ vsts_deploymentgroupname }}"

--- a/tasks/common/configure.yml
+++ b/tasks/common/configure.yml
@@ -56,12 +56,14 @@
   
   - name: Define bypass proxy urls to environment variables
     set_fact:
-      vsts_environment_variables: "{{ vsts_environment_variables + [{'name': item, 'value': vsts_proxy_bypass }] }}"
+      vsts_environment_variables: "{{ vsts_environment_variables + [{'name': item, 'value': vsts_proxy_bypass | regex_replace('\\\\', '') }] }}"
     when: vsts_proxy_bypass | length > 0
     with_items:
       - NO_PROXY
       - no_proxy
-  when: vsts_proxyurl | length > 0
+  when: 
+    - vsts_proxyurl | length > 0
+    - ansible_os_family != 'Windows'
 
 - name: Add deployment group info to install command (deployment group agent)
   set_fact:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix: Add proxy environment variables to vsts-agent .env file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For some applications, proxy variables defined by .proxy file don't work because this file define only HTTP_PROXY and HTTPS_PROXY variables (upper case), but not http_proxy and https_proxy, that is required variables from specific jobs executions. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
