### PR TITLE
fixes and improvements

### DIFF
--- a/tasks/common/configure.yml
+++ b/tasks/common/configure.yml
@@ -120,3 +120,4 @@
     - vsts_poolname | length == 0
     - vsts_deploymentgroupname | length == 0
     - vsts_environmentname | length == 0
+

--- a/tasks/linux/install.yml
+++ b/tasks/linux/install.yml
@@ -43,12 +43,10 @@
   tags: config
 
 - name: Configure VSTS agent
-  command: "{{ vsts_install_command }}"
+  command: "sudo -u {{ vsts_agent_user }} {{ vsts_install_command }}"
   args:
     chdir: "{{ vsts_agent_folder }}"
     creates: "{{ vsts_agent_folder }}/.agent"
-  become: true
-  become_user: "{{ vsts_agent_user }}"
   no_log: true
 
 - name: Install systemd service file

--- a/tasks/linux/packages.yml
+++ b/tasks/linux/packages.yml
@@ -32,7 +32,6 @@
     state: present
   loop:
     - "{{ 'python3-pip' if (ansible_distribution_major_version | int >= 20) else 'python-pip' }}"
-    - python-pexpect
     - libcurl4-gnutls-dev
     - git
   become: true

--- a/tasks/linux/reconfigure.yml
+++ b/tasks/linux/reconfigure.yml
@@ -1,10 +1,8 @@
 ---
 - name: Unconfigure VSTS agent
-  command: "./config.sh remove --unattended --auth PAT --token {{ vsts_accesstoken }}"
+  command: "sudo -u {{ vsts_agent_user }} ./config.sh remove --unattended --auth PAT --token {{ vsts_accesstoken }}"
   args:
     chdir: "{{ vsts_agent_folder }}"
-  become: true
-  become_user: "{{ vsts_agent_user }}"
   no_log: true
   tags: unconfig
 
@@ -14,11 +12,9 @@
   tags: config
 
 - name: Configure VSTS agent
-  command: "{{ vsts_install_command }}"
+  command: "sudo -u {{ vsts_agent_user }} {{ vsts_install_command }}"
   args:
     chdir: "{{ vsts_agent_folder }}"
     creates: "{{ vsts_agent_folder }}/.agent"
-  become: true
-  become_user: "{{ vsts_agent_user }}"
   no_log: true
   notify: restart vsts-agent systemd service

--- a/tasks/linux/uninstall.yml
+++ b/tasks/linux/uninstall.yml
@@ -7,11 +7,9 @@
   ignore_errors: true
 
 - name: Unconfigure VSTS agent
-  command: "./config.sh remove --unattended --auth PAT --token {{ vsts_accesstoken }}"
+  command: "sudo -u {{ vsts_agent_user }} ./config.sh remove --unattended --auth PAT --token {{ vsts_accesstoken }}"
   args:
     chdir: "{{ vsts_agent_folder }}"
-  become: true
-  become_user: "{{ vsts_agent_user }}"
   when: config_file.stat.exists
   no_log: true
   tags: unconfig


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
1. Removed python-pexpect package from the apt install task in packages.yml
2. Become unprivileged user with sudo in configure command instead of within Ansible

## Motivation and Context

1. python-pexpect doesn't exist in Ubuntu 22.04 (under that name), and it's handled by pip a step below anyway, so there's no reason to install it here. 
2. Ansible [doesn't recommend becoming an unprivileged user](https://docs.ansible.com/ansible-core/2.15/playbook_guide/playbooks_privilege_escalation.html#risks-of-becoming-an-unprivileged-user#risks-of-becoming-an-unprivileged-user), and since we're using the command module, it is safer to just use sudo -u to do this. 

## How Has This Been Tested?
Installed, reconfigured and uninstalled vsts-agent on a Ubuntu 22.04 virtual machine using the role 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
